### PR TITLE
View port information being overridden 

### DIFF
--- a/src/com/bricolsoftconsulting/geocoderplus/Geocoder.java
+++ b/src/com/bricolsoftconsulting/geocoderplus/Geocoder.java
@@ -436,7 +436,7 @@ public class Geocoder
 			
 			// Add viewport information
 			Area bounds = getAreaFromJSON(addressBounds);
-			result.setViewPort(bounds);
+			result.setBounds(bounds);
 		}
 		catch (JSONException e)
 		{


### PR DESCRIPTION
Currently the viewport information for the address is being overridden by the bounds. I've updated it so it now correctly updates the bounds instead of overriding the viewport.
